### PR TITLE
fix type error in gpu mode

### DIFF
--- a/demo_Vid4.py
+++ b/demo_Vid4.py
@@ -79,6 +79,7 @@ def main(cfg):
                 SR_y = chop_forward(LR_y_cube, net, cfg.upscale_factor)
             else:
                 SR_y = net(LR_y_cube)
+	    SR_y = SR_y.cpu()
         else:
             SR_y = net(LR_y_cube)
 


### PR DESCRIPTION
fix "TypeError: can't convert CUDA tensor to numpy. Use Tensor.cpu to copy the tensor to host memory first" error in gpu mode